### PR TITLE
ISS-33: Fixed and expanded array functions

### DIFF
--- a/Community Toolbox/scripts/tests_ArrayMaxTests/tests_ArrayMaxTests.gml
+++ b/Community Toolbox/scripts/tests_ArrayMaxTests/tests_ArrayMaxTests.gml
@@ -1,6 +1,11 @@
 function ArrayMaxTests(_run, _method) : VerrificMethodTest(_run, _method) constructor {
     static test_subject = "array_max";
     
+    // testing for especially large arrays,
+    // because original script_execute_ext(...) implementation crashed on stack overflow with ~60k items,
+    // so testing arrays/subsections with over ~65536 items should catch issues with naive script_execute_ext(...) implementation
+    static array_with_100k_items = array_create_ext(100_000, function(i) { return i; });
+    
     static should_handle_empty_array = function() {
         given_array([]);
         when_array_max_runs();
@@ -19,19 +24,60 @@ function ArrayMaxTests(_run, _method) : VerrificMethodTest(_run, _method) constr
         then_result().should_be(10);
     }
     
+    static should_handle_large_array = function() {
+        given_array(array_with_100k_items);
+        when_array_max_runs();
+        then_result().should_be(99_999);
+    }
+    
+    static should_handle_positive_offset_and_length = function() {
+        given_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        given_offset_and_length(3, 4); // should take [4, 5, 6, 7]
+        when_array_max_runs();
+        then_result().should_be(7);
+    }
+    
+    static should_handle_negative_offset = function() {
+        given_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        given_offset_and_length(-5, 3); // should take [6, 7, 8]
+        when_array_max_runs();
+        then_result().should_be(8);
+    }
+    
+    static should_handle_negative_length = function() {
+        given_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        given_offset_and_length(5, -3); // should take [6, 5, 4]
+        when_array_max_runs();
+        then_result().should_be(6);
+    }
+    
+    static should_handle_large_subsection = function() {
+        given_array(array_with_100k_items);
+        given_offset_and_length(20_000, 70_000); // should take [20000, 20001, ..., 89998, 89999]
+        when_array_max_runs();
+        then_result().should_be(89_999);
+    }
+    
     // -----
     // Setup
     // -----
     
     array = [];
+    offset = 0;
+    length = undefined;
     result = undefined;
     
     static given_array = function(_array) {
         array = _array;
     }
     
+    static given_offset_and_length = function(_offset, _length) {
+        offset = _offset;
+        length = _length;
+    }
+    
     static when_array_max_runs = function() {
-        result = array_max(array);
+        result = array_max(array, offset, length);
     }
     
     static then_result = function() {

--- a/Community Toolbox/scripts/tests_ArrayMeanTests/tests_ArrayMeanTests.gml
+++ b/Community Toolbox/scripts/tests_ArrayMeanTests/tests_ArrayMeanTests.gml
@@ -1,6 +1,11 @@
 function ArrayMeanTests(_run, _method) : VerrificMethodTest(_run, _method) constructor {
     static test_subject = "array_mean";
     
+    // testing for especially large arrays,
+    // because original script_execute_ext(...) implementation crashed on stack overflow with ~60k items,
+    // so testing arrays/subsections with over ~65536 items should catch issues with naive script_execute_ext(...) implementation
+    static array_with_100k_items = array_create_ext(100_000, function(i) { return i; });
+    
     static should_handle_empty_array = function() {
         given_array([]);
         when_array_mean_runs();
@@ -19,19 +24,60 @@ function ArrayMeanTests(_run, _method) : VerrificMethodTest(_run, _method) const
         then_result().should_be(3);
     }
     
+    static should_handle_large_array = function() {
+        given_array(array_with_100k_items);
+        when_array_mean_runs();
+        then_result().should_be(49_999.5);
+    }
+    
+    static should_handle_positive_offset_and_length = function() {
+        given_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        given_offset_and_length(3, 4); // should take [4, 5, 6, 7]
+        when_array_mean_runs();
+        then_result().should_be(5.5);
+    }
+    
+    static should_handle_negative_offset = function() {
+        given_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        given_offset_and_length(-5, 3); // should take [6, 7, 8]
+        when_array_mean_runs();
+        then_result().should_be(7);
+    }
+    
+    static should_handle_negative_length = function() {
+        given_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        given_offset_and_length(5, -3); // should take [6, 5, 4]
+        when_array_mean_runs();
+        then_result().should_be(5);
+    }
+    
+    static should_handle_large_subsection = function() {
+        given_array(array_with_100k_items);
+        given_offset_and_length(20_000, 70_000); // should take [20000, 20001, ..., 89998, 89999]
+        when_array_mean_runs();
+        then_result().should_be(54_999.5);
+    }
+    
     // -----
     // Setup
     // -----
     
     array = [];
+    offset = 0;
+    length = undefined;
     result = undefined;
     
     static given_array = function(_array) {
         array = _array;
     }
     
+    static given_offset_and_length = function(_offset, _length) {
+        offset = _offset;
+        length = _length;
+    }
+    
     static when_array_mean_runs = function() {
-        result = array_mean(array);
+        result = array_mean(array, offset, length);
     }
     
     static then_result = function() {

--- a/Community Toolbox/scripts/tests_ArrayMedianTests/tests_ArrayMedianTests.gml
+++ b/Community Toolbox/scripts/tests_ArrayMedianTests/tests_ArrayMedianTests.gml
@@ -1,6 +1,11 @@
 function ArrayMedianTests(_run, _method) : VerrificMethodTest(_run, _method) constructor {
     static test_subject = "array_median";
     
+    // testing for especially large arrays,
+    // because original script_execute_ext(...) implementation crashed on stack overflow with ~60k items,
+    // so testing arrays/subsections with over ~65536 items should catch issues with naive script_execute_ext(...) implementation
+    static array_with_100k_items = array_create_ext(100_000, function(i) { return i; });
+    
     static should_handle_empty_array = function() {
         given_array([]);
         when_array_median_runs();
@@ -26,19 +31,60 @@ function ArrayMedianTests(_run, _method) : VerrificMethodTest(_run, _method) con
         then_result().should_be(3);
     }
     
+    static should_handle_large_array = function() {
+        given_array(array_with_100k_items);
+        when_array_median_runs();
+        then_result().should_be(50_000);
+    }
+    
+    static should_handle_positive_offset_and_length = function() {
+        given_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        given_offset_and_length(3, 4); // should take [4, 5, 6, 7]
+        when_array_median_runs();
+        then_result().should_be(6);
+    }
+    
+    static should_handle_negative_offset = function() {
+        given_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        given_offset_and_length(-5, 3); // should take [6, 7, 8]
+        when_array_median_runs();
+        then_result().should_be(7);
+    }
+    
+    static should_handle_negative_length = function() {
+        given_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        given_offset_and_length(5, -3); // should take [6, 5, 4]
+        when_array_median_runs();
+        then_result().should_be(5);
+    }
+    
+    static should_handle_large_subsection = function() {
+        given_array(array_with_100k_items);
+        given_offset_and_length(20_000, 70_000); // should take [20000, 20001, ..., 89998, 89999]
+        when_array_median_runs();
+        then_result().should_be(55_000);
+    }
+    
     // -----
     // Setup
     // -----
     
     array = [];
+    offset = 0;
+    length = undefined;
     result = undefined;
     
     static given_array = function(_array) {
         array = _array;
     }
     
+    static given_offset_and_length = function(_offset, _length) {
+        offset = _offset;
+        length = _length;
+    }
+    
     static when_array_median_runs = function() {
-        result = array_median(array);
+        result = array_median(array, offset, length);
     }
     
     static then_result = function() {

--- a/Community Toolbox/scripts/tests_ArrayMinTests/tests_ArrayMinTests.gml
+++ b/Community Toolbox/scripts/tests_ArrayMinTests/tests_ArrayMinTests.gml
@@ -1,6 +1,11 @@
 function ArrayMinTests(_run, _method) : VerrificMethodTest(_run, _method) constructor {
     static test_subject = "array_min";
     
+    // testing for especially large arrays,
+    // because original script_execute_ext(...) implementation crashed on stack overflow with ~60k items,
+    // so testing arrays/subsections with over ~65536 items should catch issues with naive script_execute_ext(...) implementation
+    static array_with_100k_items = array_create_ext(100_000, function(i) { return i; });
+    
     static should_handle_empty_array = function() {
         given_array([]);
         when_array_min_runs();
@@ -19,19 +24,60 @@ function ArrayMinTests(_run, _method) : VerrificMethodTest(_run, _method) constr
         then_result().should_be(-5);
     }
     
+    static should_handle_large_array = function() {
+        given_array(array_with_100k_items);
+        when_array_min_runs();
+        then_result().should_be(0);
+    }
+    
+    static should_handle_positive_offset_and_length = function() {
+        given_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        given_offset_and_length(3, 4); // should take [4, 5, 6, 7]
+        when_array_min_runs();
+        then_result().should_be(4);
+    }
+    
+    static should_handle_negative_offset = function() {
+        given_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        given_offset_and_length(-5, 3); // should take [6, 7, 8]
+        when_array_min_runs();
+        then_result().should_be(6);
+    }
+    
+    static should_handle_negative_length = function() {
+        given_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        given_offset_and_length(5, -3); // should take [6, 5, 4]
+        when_array_min_runs();
+        then_result().should_be(4);
+    }
+    
+    static should_handle_large_subsection = function() {
+        given_array(array_with_100k_items);
+        given_offset_and_length(20_000, 70_000); // should take [20000, 20001, ..., 89998, 89999]
+        when_array_min_runs();
+        then_result().should_be(20_000);
+    }
+    
     // -----
     // Setup
     // -----
     
     array = [];
+    offset = 0;
+    length = undefined;
     result = undefined;
     
     static given_array = function(_array) {
         array = _array;
     }
     
+    static given_offset_and_length = function(_offset, _length) {
+        offset = _offset;
+        length = _length;
+    }
+    
     static when_array_min_runs = function() {
-        result = array_min(array);
+        result = array_min(array, offset, length);
     }
     
     static then_result = function() {

--- a/Community Toolbox/scripts/tests_ArraySumTests/tests_ArraySumTests.gml
+++ b/Community Toolbox/scripts/tests_ArraySumTests/tests_ArraySumTests.gml
@@ -1,6 +1,11 @@
 function ArraySumTests(_run, _method) : VerrificMethodTest(_run, _method) constructor {
     static test_subject = "array_sum";
     
+    // testing for especially large arrays,
+    // because original script_execute_ext(...) implementation crashed on stack overflow with ~60k items,
+    // so testing arrays/subsections with over ~65536 items should catch issues with naive script_execute_ext(...) implementation
+    static array_with_100k_items = array_create_ext(100_000, function(i) { return i; });
+    
     static should_handle_empty_array = function() {
         given_array([]);
         when_array_sum_runs();
@@ -19,19 +24,60 @@ function ArraySumTests(_run, _method) : VerrificMethodTest(_run, _method) constr
         then_result().should_be(12);
     }
     
+    static should_handle_large_array = function() {
+        given_array(array_with_100k_items);
+        when_array_sum_runs();
+        then_result().should_be(4_999_950_000);
+    }
+    
+    static should_handle_positive_offset_and_length = function() {
+        given_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        given_offset_and_length(3, 4); // should take [4, 5, 6, 7]
+        when_array_sum_runs();
+        then_result().should_be(22);
+    }
+    
+    static should_handle_negative_offset = function() {
+        given_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        given_offset_and_length(-5, 3); // should take [6, 7, 8]
+        when_array_sum_runs();
+        then_result().should_be(21);
+    }
+    
+    static should_handle_negative_length = function() {
+        given_array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        given_offset_and_length(5, -3); // should take [6, 5, 4]
+        when_array_sum_runs();
+        then_result().should_be(15);
+    }
+    
+    static should_handle_large_subsection = function() {
+        given_array(array_with_100k_items);
+        given_offset_and_length(20_000, 70_000); // should take [20000, 20001, ..., 89998, 89999]
+        when_array_sum_runs();
+        then_result().should_be(3_849_965_000);
+    }
+    
     // -----
     // Setup
     // -----
     
     array = [];
+    offset = 0;
+    length = undefined;
     result = undefined;
     
     static given_array = function(_array) {
         array = _array;
     }
     
+    static given_offset_and_length = function(_offset, _length) {
+        offset = _offset;
+        length = _length;
+    }
+    
     static when_array_sum_runs = function() {
-        result = array_sum(array);
+        result = array_sum(array, offset, length);
     }
     
     static then_result = function() {

--- a/Community Toolbox/scripts/utils_Array/utils_Array.gml
+++ b/Community Toolbox/scripts/utils_Array/utils_Array.gml
@@ -1,43 +1,169 @@
-/// @func array_max(array)
-/// @desc Returns the highest number from the array, or 0 if the array is empty.
-/// @arg {Array<Real>} array
+/// @func array_max(array,[offset],[length])
+/// @desc Returns the highest number from the array or its subsection. If the array/subsection is empty, 0 is returned.
+/// @arg {Array<Real>} array    The array to get the maximum value of.
+/// @arg {Real} [offset]        The starting index of the subsection (for a negative offset, it will count from array end).
+/// @arg {Real} [length]        The length of the subsection (for a negative length, it will count backwards from the offset position).
 /// @returns {Real}
-function array_max(_array) {
-    return script_execute_ext(max, _array);
+function array_max(_array, _offset = 0, _length = undefined) {
+    // resolving the offset and length
+    var _arrlength = array_length(_array);
+    _length ??= _arrlength;
+    
+    if (_offset < 0)
+        _offset = max(_arrlength + _offset, 0);
+    
+    if (_length < 0) {
+        _length = min(_offset + 1, -_length);
+        _offset -= _length - 1;
+    }
+    
+    if (_length == 0 || _offset >= _arrlength)
+        return 0;
+    
+    // performing the actual calculation
+    if (_length <= 10000)
+        return script_execute_ext(max, _array, _offset, _length);
+    
+    var _max = -infinity;
+    for (var i = 0; i < _length; i += 10000) {
+        var _partial_max = script_execute_ext(max, _array, _offset + i, min(10000, _length - i));
+        _max = max(_max, _partial_max);
+    }
+    return _max;
 } 
 
-/// @func array_min(array)
-/// @desc Returns the lowest number from the array, or 0 if the array is empty.
-/// @arg {Array<Real>} array
+/// @func array_min(array,[offset],[length])
+/// @desc Returns the lowest number from the array or its subsection. If the array/subsection is empty, 0 is returned.
+/// @arg {Array<Real>} array    The array to get the minimum value of.
+/// @arg {Real} [offset]        The starting index of the subsection (for a negative offset, it will count from array end).
+/// @arg {Real} [length]        The length of the subsection (for a negative length, it will count backwards from the offset position).
 /// @returns {Real}
-function array_min(_array) {
-    return script_execute_ext(min, _array);
-}
-
-/// @func array_mean(array)
-/// @desc Returns the average value of the numbers in the array, or 0 if the array is empty.
-/// @arg {Array<Real>} array
-/// @returns {Real}
-function array_mean(_array) {
-    return script_execute_ext(mean, _array);
-}
-
-/// @func array_median(array)
-/// @desc Returns the middle number from the array, or 0 if the array is empty. Given an even items count, returns the larger of two middle numbers.
-/// @arg {Array<Real>} array
-/// @returns {Real}
-function array_median(_array) {
-    return script_execute_ext(median, _array);
-}
-
-/// @func array_sum(array)
-/// @desc Returns the sum of numbers from the array.
-/// @arg {Array<Real>} array
-/// @returns {Real}
-function array_sum(_array) {
-    var _total = 0;
-    for (var i = array_length(_array)-1; i >= 0; --i) {
-        _total += _array[i];
+function array_min(_array, _offset = 0, _length = undefined) {
+    // resolving the offset and length
+    var _arrlength = array_length(_array);
+    _length ??= _arrlength;
+    
+    if (_offset < 0)
+        _offset = max(_arrlength + _offset, 0);
+    
+    if (_length < 0) {
+        _length = min(_offset + 1, -_length);
+        _offset -= _length - 1;
     }
-    return _total;
+    
+    if (_length == 0 || _offset >= _arrlength)
+        return 0;
+    
+    // performing the actual calculation
+    if (_length <= 10000)
+        return script_execute_ext(min, _array, _offset, _length);
+    
+    var _min = +infinity;
+    for (var i = 0; i < _length; i += 10000) {
+        var _partial_max = script_execute_ext(min, _array, _offset + i, min(10000, _length - i));
+        _min = min(_min, _partial_max);
+    }
+    return _min;
+}
+
+/// @func array_mean(array,[offset],[length])
+/// @desc Returns the average value of numbers in the array or its subsection. If the array/subsection is empty, 0 is returned.
+/// @arg {Array<Real>} array    The array to get the mean value of.
+/// @arg {Real} [offset]        The starting index of the subsection (for a negative offset, it will count from array end).
+/// @arg {Real} [length]        The length of the subsection (for a negative length, it will count backwards from the offset position).
+/// @returns {Real}
+function array_mean(_array, _offset = 0, _length = undefined) {
+    // resolving the offset and length
+    var _arrlength = array_length(_array);
+    _length ??= _arrlength;
+    
+    if (_offset < 0)
+        _offset = max(_arrlength + _offset, 0);
+    
+    if (_length < 0) {
+        _length = min(_offset + 1, -_length);
+        _offset -= _length - 1;
+    }
+    
+    if (_length == 0 || _offset >= _arrlength)
+        return 0;
+    
+    // performing the actual calculation
+    if (_length <= 10000)
+        return script_execute_ext(mean, _array, _offset, _length);
+    
+    return array_sum(_array, _offset, _length) / _length;
+}
+
+/// @func array_median(array,[offset],[length])
+/// @desc Returns the middle number from the array or its subsection. If two middle numbers are present, the higher is returned. If the array/subsection is empty, 0 is returned.
+/// @arg {Array<Real>} array    The array to get the median value of.
+/// @arg {Real} [offset]        The starting index of the subsection (for a negative offset, it will count from array end).
+/// @arg {Real} [length]        The length of the subsection (for a negative length, it will count backwards from the offset position).
+/// @returns {Real}
+function array_median(_array, _offset = 0, _length = undefined) {
+    // resolving the offset and length
+    var _arrlength = array_length(_array);
+    _length ??= _arrlength;
+    
+    if (_offset < 0)
+        _offset = max(_arrlength + _offset, 0);
+    
+    if (_length < 0) {
+        _length = min(_offset + 1, -_length);
+        _offset -= _length - 1;
+    }
+    
+    if (_length == 0 || _offset >= _arrlength)
+        return 0;
+    
+    // performing the actual calculation
+    if (_length <= 10000) {
+        return script_execute_ext(median, _array, _offset, _length);
+    } else {
+        // I know there is this neat "median of medians" algorithm that can find the median in O(n) time
+        // thus making it seemingly preferable for larger datasets than array_sorting
+        // but the algorithm is pretty complex, and requires lots of swaps along the way
+        // so the overhead of running lots of GML might outweigh the O(n) benefits, maybe except for the most extreme cases
+        var _new_array = array_create(_length, 0);
+        array_copy(_new_array, 0, _array, _offset, _length);
+        array_sort(_new_array, true);
+        return _new_array[_length div 2];
+    }
+}
+
+/// @func array_sum(array,[offset],[length])
+/// @desc Returns the sum of numbers in the array or its subsection. If the array/subsection is empty, 0 is returned.
+/// @arg {Array<Real>} array    The array to get the sum of.
+/// @arg {Real} [offset]        The starting index of the subsection (for a negative offset, it will count from array end).
+/// @arg {Real} [length]        The length of the subsection (for a negative length, it will count backwards from the offset position).
+/// @returns {Real}
+function array_sum(_array, _offset = 0, _length = undefined) {
+    // resolving the offset and length
+    var _arrlength = array_length(_array);
+    _length ??= _arrlength;
+    
+    if (_offset < 0)
+        _offset = max(_arrlength + _offset, 0);
+    
+    if (_length < 0) {
+        _length = min(_offset + 1, -_length);
+        _offset -= _length - 1;
+    }
+    
+    if (_length == 0 || _offset >= _arrlength)
+        return 0;
+    
+    // performing the actual calculation
+    if (code_is_compiled()) {
+        // on YYC, basic addition loop is faster
+        var _total = 0;
+        for (var i = _offset + _length - 1; i >= _offset; i--) {
+            _total += _array[i];
+        }
+        return _total;
+    } else {
+        // on VM, array_reduce is faster instead
+        return array_reduce(_array, function(_previous, _current) { return _previous + _current; }, 0, _offset, _length);
+    }
 }


### PR DESCRIPTION
As it turned out, using plain `script_execute_ext(...)` with large arrays caused some stack overflow error. More details in issue #33 

Also, I added extra offset and length parameters, working similarly to same parameters in native array functions (like `array_filter` or `array_map`). Generally:
- a positive offset is counted forward from the start of the array; a negative offset is counted backwards from the end of the array (with -1 being the last element index, or array length minus one); if absolute value of negative offset exceeds array length, offset of 0 is used
- a positive length counts items forward from the offset (included); a negative length counts items backwards from the offset (also included); if the length exceeds available items (e.g. from 7th offset onwards there are only 5 items, and length of 10 was given), then only the available items are processed