### PR TITLE
ISS-37: Installed Verrific 0.1.1

### DIFF
--- a/Community Toolbox/scripts/struct_VerrificAsserter/struct_verrificasserter.gml
+++ b/Community Toolbox/scripts/struct_VerrificAsserter/struct_verrificasserter.gml
@@ -1,6 +1,6 @@
 /// @func VerrificAsserter(run)
 /// @desc A struct for performing assertions for the given test run.
-/// @arg {Struct.VerrificTestItem} run      The test run to perform assertions on.
+/// @arg {Struct.VerrificTestRun} run       The test run to perform assertions on.
 function VerrificAsserter(_run) constructor {
     test_run = _run;
     
@@ -334,6 +334,24 @@ function VerrificAsserter(_run) constructor {
     static assert_equal = function(_expected, _actual, _onfailure = undefined) {
         _onfailure ??= $"The value should be '{_expected}' but is '{_actual}' instead.";
         return assert_that(_expected == _actual, _onfailure);
+    }
+    
+    #endregion
+    
+    // --------------------
+    // Miscellaneous checks
+    // --------------------
+    
+    #region
+    
+    /// @func assert_is_one_of(items,actual,onfailure)
+    /// @desc Asserts that a given value is equal to one of expected values.
+    /// @arg {Array} items          The possible expected values.
+    /// @arg {Any} actual           The actual value.
+    /// @arg {String} onfailure     A custom message to show in case of a failure.
+    static assert_is_one_of = function(_items, _actual, _onfailure = undefined) {
+        _onfailure ??= $"The value should be oe of '{_items}' but is '{_actual}' instead.";
+        return assert_that(array_contains(_items, _actual), _onfailure);
     }
     
     #endregion

--- a/Community Toolbox/scripts/struct_VerrificNumericAssertion/struct_VerrificNumericAssertion.gml
+++ b/Community Toolbox/scripts/struct_VerrificNumericAssertion/struct_VerrificNumericAssertion.gml
@@ -17,6 +17,16 @@ function VerrificNumericAssertion(_asserter, _actual) constructor {
         return self;
     }
     
+    /// @func should_be_one_of(items,[onfailure])
+    /// @desc Asserts that the given numeric value is equal to one of expected values.
+    /// @arg {Array} items          The possible expected values.
+    /// @arg {String} onfailure     A custom message to show in case of a failure.
+    static should_be_one_of = function(_items, _onfailure = undefined) {
+        if (can_assert)
+            asserter.assert_is_one_of(_items, actual, _onfailure);
+        return self;
+    }
+    
     // ------------
     // Value checks
     // ------------

--- a/Community Toolbox/scripts/struct_VerrificStringAssertion/struct_VerrificStringAssertion.gml
+++ b/Community Toolbox/scripts/struct_VerrificStringAssertion/struct_VerrificStringAssertion.gml
@@ -17,6 +17,16 @@ function VerrificStringAssertion(_asserter, _actual) constructor {
         return self;
     }
     
+    /// @func should_be_one_of(items,[onfailure])
+    /// @desc Asserts that the given string is equal to one of expected values.
+    /// @arg {Array} items          The possible expected values.
+    /// @arg {String} onfailure     A custom message to show in case of a failure.
+    static should_be_one_of = function(_items, _onfailure = undefined) {
+        if (can_assert)
+            asserter.assert_is_one_of(_items, actual, _onfailure);
+        return self;
+    }
+    
     /// @func should_be_empty(expected,[onfailure])
     /// @desc Asserts that the given string is empty.
     /// @arg {String} onfailure     A custom message to show in case of a failure.

--- a/Community Toolbox/scripts/struct_VerrificTest/struct_verrifictest.gml
+++ b/Community Toolbox/scripts/struct_VerrificTest/struct_verrifictest.gml
@@ -341,4 +341,21 @@ function VerrificTest(_run) constructor {
     }
     
     #endregion
+    
+    // --------------------
+    // Miscellaneous checks
+    // --------------------
+    
+    #region
+    
+    /// @func assert_is_one_of(items,actual,onfailure)
+    /// @desc Asserts that a given value is equal to one of expected values.
+    /// @arg {Array} items          The possible expected values.
+    /// @arg {Any} actual           The actual value.
+    /// @arg {String} onfailure     A custom message to show in case of a failure.
+    static assert_is_one_of = function(_items, _actual, _onfailure = undefined) {
+        return test_asserter.assert_is_one_of(_items, _actual, _onfailure);
+    }
+    
+    #endregion
 }

--- a/Community Toolbox/scripts/struct_VerrificTestNode/struct_verrifictestnode.gml
+++ b/Community Toolbox/scripts/struct_VerrificTestNode/struct_verrifictestnode.gml
@@ -28,7 +28,7 @@ function VerrificTestNode(_suite, _index, _stub) : VerrificTreeNode(_suite, _ind
     /// @func run()
     /// @desc Runs the test.
     static run = function() {
-        if (!instance_exists(test_run))
+        if (is_undefined(test_run))
             test_run = new VerrificTestRun(test_stub);
         
         test_run.execute();


### PR DESCRIPTION
As described in issue #37, a Verrific update to package version 0.1.1 is needed for is-value-in-array assertion that would be used in PR #35.

(while the PR in question has its own Verrific changes, I made a separate update instead, to avoid two different development paths emerging between mainline Verrific and Community Toolbox Verrific)