### PR TITLE
#26: Implement array_get_random / array_pop_random (again)

### DIFF
--- a/Community Toolbox/objects/ctrl_ArrayUtilities/Create_0.gml
+++ b/Community Toolbox/objects/ctrl_ArrayUtilities/Create_0.gml
@@ -1,15 +1,32 @@
 title = "Array Utilities";
-description = "Calculate the maximum, minimum, median, mean, and sum values of an array of numbers.";
+description = "Calculate the maximum, minimum, median, mean, and sum, and get/pop random values, of an array.";
 
-the_array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-input_array = -1;
+the_original_array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
-the_array_display = "";
-the_array_max = 0;
-the_array_min = 0;
-the_array_median = 0;
-the_array_mean = 0;
-the_array_sum = 0;
+reset_defaults = function() {
+    input_array = -1;
+    input_offset = -1;
+    input_length = -1;
+
+    the_array = [];
+    array_copy(the_array, 0, the_original_array, 0, array_length(the_original_array));
+
+    the_array_display = "";
+    the_array_max = 0;
+    the_array_min = 0;
+    the_array_median = 0;
+    the_array_mean = 0;
+    the_array_sum = 0;
+
+    the_array_offset = 0;
+    the_array_length = undefined;
+
+    last_value_get = undefined;
+    last_value_pop = undefined;
+    
+    recompute_values();
+}
+
 
 popup_input_array = function() {
     if (input_array == -1) {
@@ -17,19 +34,64 @@ popup_input_array = function() {
     }
 }
 
-recompute_values = function() {
-    the_array_display = string_join_ext(",", the_array);
-    the_array_max = array_max(the_array);
-    the_array_min = array_min(the_array);
-    the_array_median = array_median(the_array);
-    the_array_mean = array_mean(the_array);
-    the_array_sum = array_sum(the_array);
+set_offset_array = function() {
+    if (input_offset == -1) {
+        input_offset = get_string_async("Enter the offset to consider for operations:", the_array_offset);
+    }
 }
 
-recompute_values();
+set_length_array = function() {
+    if (input_length == -1) {
+        input_length = get_string_async("Enter the length to consider for operations:", the_array_length);
+    }
+}
+
+get_random_array = function() {
+    last_value_get = array_get_random(the_array, the_array_offset, the_array_length);
+}
+
+pop_random_array = function() {
+    last_value_pop = array_pop_random(the_array, the_array_offset, the_array_length);
+    recompute_values();
+}
+
+recompute_values = function() {
+    the_array_display = string_join_ext(",", the_array);
+    the_array_max = array_max(the_array, the_array_offset, the_array_length);
+    the_array_min = array_min(the_array, the_array_offset, the_array_length);
+    the_array_median = array_median(the_array, the_array_offset, the_array_length);
+    the_array_mean = array_mean(the_array, the_array_offset, the_array_length);
+    the_array_sum = array_sum(the_array, the_array_offset, the_array_length);
+}
+
+
+reset_defaults();
+
 
 // Creating UI controls
 
 instance_create_layer(32, 80, layer, ui_Button, {
     text: "Change Array", on_click: popup_input_array, image_xscale: 6
+});
+
+instance_create_layer(256+32, 80, layer, ui_Button, {
+    text: "Set offset", on_click: set_offset_array, image_xscale: 6
+});
+
+instance_create_layer(256*2+32, 80, layer, ui_Button, {
+    text: "Set length", on_click: set_length_array, image_xscale: 6
+});
+
+
+
+instance_create_layer(32, 300, layer, ui_Button, {
+    text: "Get Random", on_click: get_random_array, image_xscale: 6
+});
+
+instance_create_layer(256+32, 300, layer, ui_Button, {
+    text: "Pop Random", on_click: pop_random_array, image_xscale: 6
+});
+
+instance_create_layer(256*2+32, 300, layer, ui_Button, {
+    text: "Reset to Defaults", on_click: reset_defaults, image_xscale: 6
 });

--- a/Community Toolbox/objects/ctrl_ArrayUtilities/Draw_64.gml
+++ b/Community Toolbox/objects/ctrl_ArrayUtilities/Draw_64.gml
@@ -3,7 +3,7 @@ draw_set_halign(fa_left);
 draw_set_valign(fa_top);
 
 draw_text(16, 16, title);
-draw_text_ext(16, 48, description, -1, room_width - 352);
+draw_text_ext(16, 48, description, -1, room_width - 320);
 
 draw_text(
     16,
@@ -15,3 +15,23 @@ draw_text(
     $"array_mean(array): {the_array_mean}\n" +
     $"array_sum(array): {the_array_sum}\n"
     );
+
+draw_text(
+    256 + 32,
+    128,
+    $"offset: {the_array_offset}");
+    
+
+draw_text(
+    256 * 2 + 32,
+    128,
+    $"length: {the_array_length}");
+    
+
+draw_text(
+    16,
+    384,
+    $"last gotten value: {last_value_get}\n" + 
+    $"last popped value: {last_value_pop}\n"
+    );
+    

--- a/Community Toolbox/objects/ctrl_ArrayUtilities/Other_63.gml
+++ b/Community Toolbox/objects/ctrl_ArrayUtilities/Other_63.gml
@@ -16,3 +16,25 @@ if (async_load[? "id"] == input_array) {
     }
     input_array = -1;
 }
+
+if (async_load[? "id"] == input_offset) {
+    if (async_load[? "status"]) {
+        try {
+            the_array_offset = real(async_load[? "result"]);
+        }
+        catch (ex) {}
+        recompute_values();
+    }
+    input_offset = -1;
+}
+
+if (async_load[? "id"] == input_length) {
+    if (async_load[? "status"]) {
+        try {
+            the_array_length = real(async_load[? "result"]);
+        }
+        catch (ex) {}
+        recompute_values();
+    }
+    input_length = -1;
+}

--- a/Community Toolbox/scripts/suite_ArrayUtilsSuite/suite_ArrayUtilsSuite.gml
+++ b/Community Toolbox/scripts/suite_ArrayUtilsSuite/suite_ArrayUtilsSuite.gml
@@ -5,6 +5,8 @@ function ArrayUtilsSuite() : VerrificSuiteGroup("Array utilities tests") constru
         ArrayMeanTests,
         ArrayMedianTests,
         ArraySumTests,
+		ArrayGetRandomTests,
+		ArrayPopRandomTests,
     ], function(test) {
         add_methods_from(test);
     });

--- a/Community Toolbox/scripts/tests_ArrayGetRandomTests/tests_ArrayGetRandomTests.gml
+++ b/Community Toolbox/scripts/tests_ArrayGetRandomTests/tests_ArrayGetRandomTests.gml
@@ -1,0 +1,101 @@
+function ArrayGetRandomTests(_run, _method) : VerrificMethodTest(_run, _method) constructor {
+    static test_subject = "array_get_random";
+
+    static should_handle_empty_array = function() {
+        given_array([]);
+        when_array_get_random_runs();
+        then_result().should_be(0);
+    }
+    
+    static should_return_value_from_original_array = function() {
+        given_array([100, 300, 500, 700, 900]);
+        when_array_get_random_runs();
+        then_result().should_be_one_of([100, 300, 500, 700, 900]);
+    }
+    
+    static should_return_value_from_original_1_length_array = function() {
+        given_array(["Hi"]);
+        when_array_get_random_runs();
+        then_string_result().should_be("Hi");
+    }
+    
+    static should_respect_offset = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_offset(3);
+        when_array_get_random_runs();
+        then_result().should_be_one_of([4,5,6,7,8,9,0]);
+    }
+    
+    static should_respect_length = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_length(4);
+        when_array_get_random_runs();
+        then_result().should_be_one_of([1,2,3,4]);
+    }
+    
+    static should_respect_negative_offset = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_offset(-3);
+        when_array_get_random_runs();
+        then_result().should_be_one_of([8,9,0]);
+    }
+    
+    static should_respect_negative_length = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_offset(5);
+        given_length(-2);
+        when_array_get_random_runs();
+        then_result().should_be_one_of([5,6]);
+    }
+    
+    static should_return_zero_for_zero_length = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_length(0);
+        when_array_get_random_runs();
+        then_result().should_be(0);
+    }
+    
+    static should_respect_negative_offset_and_positive_length = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_offset(-5);
+        given_length(4);
+        when_array_get_random_runs();
+        then_result().should_be_one_of([6,7,8,9]);
+    }
+    
+ 
+    // -----
+    // Setup
+    // -----
+    
+    array = [];
+    offset = undefined;
+    length = undefined;
+    result = undefined;
+        
+    static given_array = function(_array) {
+        array = _array; 
+        offset = undefined;
+        length = undefined;
+    }
+    
+    static given_offset = function(_offset) {
+        offset = _offset;
+    }
+    
+    static given_length = function(_length) {
+        length = _length;        
+    }
+    
+    static when_array_get_random_runs = function() {
+        result = array_get_random(array, offset, length);
+    }
+        
+    static then_result = function() {
+        return new VerrificNumericAssertion(test_asserter, result);
+    }
+    
+    static then_string_result = function() {
+        return new VerrificStringAssertion(test_asserter, result);
+    }
+}

--- a/Community Toolbox/scripts/tests_ArrayPopRandomTests/tests_ArrayPopRandomTests.gml
+++ b/Community Toolbox/scripts/tests_ArrayPopRandomTests/tests_ArrayPopRandomTests.gml
@@ -1,0 +1,111 @@
+function ArrayPopRandomTests(_run, _method) : VerrificMethodTest(_run, _method) constructor {
+    static test_subject = "array_pop_random";
+    
+    static should_handle_empty_array = function() {
+        given_array([]);
+        when_array_pop_random_runs();
+        then_result().should_be(0);
+    }
+    
+    static should_return_value_from_original_array = function() {
+        given_array([100, 300, 500, 700, 900]);
+        when_array_pop_random_runs();
+        then_result().should_be_one_of([100, 300, 500, 700, 900]);
+    }
+    
+    static should_return_value_from_original_1_length_array = function() {
+        given_array(["Hi"]);
+        when_array_pop_random_runs();
+        then_string_result().should_be("Hi");
+    }
+    
+    static should_return_empty_array_when_running_over_1_length_array = function() {
+        given_array(["Hi"]);
+        after_array_pop_random_runs_and_result_is_array_length();
+        then_result().should_be(0);
+    }
+    
+    static should_respect_offset = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_offset(3);
+        when_array_pop_random_runs();
+        then_result().should_be_one_of([4,5,6,7,8,9,0]);
+    }
+    
+    static should_respect_length = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_length(4);
+        when_array_pop_random_runs();
+        then_result().should_be_one_of([1,2,3,4]);
+    }
+    
+    static should_respect_negative_offset = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_offset(-3);
+        when_array_pop_random_runs();
+        then_result().should_be_one_of([8,9,0]);
+    }
+    
+    static should_respect_negative_length = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_offset(5);
+        given_length(-2);
+        when_array_pop_random_runs();
+        then_result().should_be_one_of([5,6]);
+    }
+    
+    static should_respect_negative_offset_and_length = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_offset(-3);
+        given_length(-4);
+        when_array_pop_random_runs();
+        then_result().should_be_one_of([5,6,7,8]);
+    }
+    
+    static should_handle_zero_length = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_length(0);
+        when_array_pop_random_runs();
+        then_result().should_be(0);
+    }
+    
+    // -----
+    // Setup
+    // -----
+    
+    array = [];
+    offset = undefined;
+    length = undefined;
+    result = undefined;
+    
+    static given_array = function(_array) {
+        array = _array; 
+        offset = undefined;
+        length = undefined;
+    }
+    
+    static given_offset = function(_offset) {
+        offset = _offset;
+    }
+    
+    static given_length = function(_length) {
+        length = _length;        
+    }
+    
+    static when_array_pop_random_runs = function() {
+        result = array_pop_random(array, offset, length);
+    }
+    
+    static after_array_pop_random_runs_and_result_is_array_length = function() {
+        var _elem = array_pop_random(array, offset, length);
+        result = array_length(array);
+    }
+        
+    static then_result = function() {
+        return new VerrificNumericAssertion(test_asserter, result);
+    }
+    
+    static then_string_result = function() {
+        return new VerrificStringAssertion(test_asserter, result);
+    }
+}

--- a/Community Toolbox/scripts/utils_Array/utils_Array.gml
+++ b/Community Toolbox/scripts/utils_Array/utils_Array.gml
@@ -172,3 +172,62 @@ function array_sum(_array, _offset = 0, _length = undefined) {
         return array_reduce(_array, function(_previous, _current) { return _previous + _current; }, 0, _offset, _length);
     }
 }
+
+/// @func       array_get_random(array,[offset],[length])
+/// @desc       Returns a random element from the array (or a range within it). If the array/subsection is empty it will return zero.
+/// @arg        {Array<Real>}    array       the desired array
+/// @arg        {Real}           [offset]    optional 0-based offset to use. By default 0. Can be negative (will wrap around)
+/// @arg        {Real}           [length]    optional length of items to select from, starting from offset (for a negative length, it will count backwards from the offset position). By default array_length(array).
+/// @returns    {Any}            a random item from the array
+function array_get_random(_array, _offset=0, _length=undefined) {
+    // resolving the offset and length
+    var _arrlength = array_length(_array);
+    _length ??= _arrlength;
+    
+    if (_offset < 0)
+        _offset = max(_arrlength + _offset, 0);
+    
+    if (_length < 0) {
+        _length = min(_offset + 1, -_length);
+        _offset -= _length - 1;
+    }
+    
+    _length = min(_arrlength - _offset, _length);
+    if (_length <= 0)
+        return 0;
+    
+	// getting the random value	
+    var _index = irandom_range(_offset, _offset + _length - 1);
+    return _array[_index];
+}
+
+
+/// @func       array_pop_random(array,[offset],[length])
+/// @desc       Pops a random element from the array (or a range within it). If the array is empty or the length is nonpositive it will return zero.
+/// @arg        {Array<Real>}    array       the desired array
+/// @arg        {Real}           [offset]    optional 0-based offset to use. By default 0. Can be negative (will wrap around)
+/// @arg        {Real}           [length]    optional length of items to select from, starting from offset (for a negative length, it will count backwards from the offset position). By default array_length(array).
+/// @returns    {Any}            a random item from the array
+function array_pop_random(_array, _offset=0, _length=undefined) {
+    // resolving the offset and length
+    var _arrlength = array_length(_array);
+    _length ??= _arrlength;
+    
+    if (_offset < 0)
+        _offset = max(_arrlength + _offset, 0);
+    
+    if (_length < 0) {
+        _length = min(_offset + 1, -_length);
+        _offset -= _length - 1;
+    }
+    
+    _length = min(_arrlength - _offset, _length);
+    if (_length <= 0)
+        return 0;
+    
+    // popping the value
+    var _index = irandom_range(_offset, _offset + _length - 1);
+    var _element = _array[_index];
+    array_delete(_array, _index, 1);
+    return _element;        
+}


### PR DESCRIPTION
- Reworked implementation using offset/length code from other array functions
- Reworked tests to consider should_be_one_of Verrific assertion
- Redid demo, implementing length and offset for the already existing functions and allowing to get/pop values as well (and reset values to default)