### PR TITLE
ISS-26: Implement array_get_random / array_pop_random (yet again)

### DIFF
--- a/Community Toolbox/Community Toolbox.yyp
+++ b/Community Toolbox/Community Toolbox.yyp
@@ -41,6 +41,7 @@
   },
   "resources": [
     {"id":{"name":"tests_ArrayMinTests","path":"scripts/tests_ArrayMinTests/tests_ArrayMinTests.yy",},},
+    {"id":{"name":"tests_ArrayGetRandomTests","path":"scripts/tests_ArrayGetRandomTests/tests_ArrayGetRandomTests.yy",},},
     {"id":{"name":"demo_UnlerpRelerp","path":"rooms/demo_UnlerpRelerp/demo_UnlerpRelerp.yy",},},
     {"id":{"name":"enum_VerrificStatus","path":"scripts/enum_VerrificStatus/enum_VerrificStatus.yy",},},
     {"id":{"name":"tests_IsNullishTests","path":"scripts/tests_IsNullishTests/tests_IsNullishTests.yy",},},
@@ -95,6 +96,7 @@
     {"id":{"name":"struct_VerrificTest","path":"scripts/struct_VerrificTest/struct_VerrificTest.yy",},},
     {"id":{"name":"utils_Array","path":"scripts/utils_Array/utils_Array.yy",},},
     {"id":{"name":"ui_UnlerpRelerpSlider","path":"objects/ui_UnlerpRelerpSlider/ui_UnlerpRelerpSlider.yy",},},
+    {"id":{"name":"tests_ArrayPopRandomTests","path":"scripts/tests_ArrayPopRandomTests/tests_ArrayPopRandomTests.yy",},},
     {"id":{"name":"utils_Math","path":"scripts/utils_Math/utils_Math.yy",},},
     {"id":{"name":"struct_VerrificMethodTest","path":"scripts/struct_VerrificMethodTest/struct_VerrificMethodTest.yy",},},
     {"id":{"name":"struct_VerrificLogLine","path":"scripts/struct_VerrificLogLine/struct_VerrificLogLine.yy",},},

--- a/Community Toolbox/objects/ctrl_ArrayUtilities/Create_0.gml
+++ b/Community Toolbox/objects/ctrl_ArrayUtilities/Create_0.gml
@@ -1,15 +1,32 @@
 title = "Array Utilities";
-description = "Calculate the maximum, minimum, median, mean, and sum values of an array of numbers.";
+description = "Calculate the maximum, minimum, median, mean, and sum, and get/pop random values, of an array.";
 
-the_array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-input_array = -1;
+the_original_array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
-the_array_display = "";
-the_array_max = 0;
-the_array_min = 0;
-the_array_median = 0;
-the_array_mean = 0;
-the_array_sum = 0;
+reset_defaults = function() {
+    input_array = -1;
+    input_offset = -1;
+    input_length = -1;
+
+    the_array = [];
+    array_copy(the_array, 0, the_original_array, 0, array_length(the_original_array));
+
+    the_array_display = "";
+    the_array_max = 0;
+    the_array_min = 0;
+    the_array_median = 0;
+    the_array_mean = 0;
+    the_array_sum = 0;
+
+    the_array_offset = 0;
+    the_array_length = undefined;
+
+    last_value_get = undefined;
+    last_value_pop = undefined;
+    
+    recompute_values();
+}
+
 
 popup_input_array = function() {
     if (input_array == -1) {
@@ -17,19 +34,64 @@ popup_input_array = function() {
     }
 }
 
-recompute_values = function() {
-    the_array_display = string_join_ext(",", the_array);
-    the_array_max = array_max(the_array);
-    the_array_min = array_min(the_array);
-    the_array_median = array_median(the_array);
-    the_array_mean = array_mean(the_array);
-    the_array_sum = array_sum(the_array);
+set_offset_array = function() {
+    if (input_offset == -1) {
+        input_offset = get_string_async("Enter the offset to consider for operations:", the_array_offset);
+    }
 }
 
-recompute_values();
+set_length_array = function() {
+    if (input_length == -1) {
+        input_length = get_string_async("Enter the length to consider for operations:", the_array_length);
+    }
+}
+
+get_random_array = function() {
+    last_value_get = array_get_random(the_array, the_array_offset, the_array_length);
+}
+
+pop_random_array = function() {
+    last_value_pop = array_pop_random(the_array, the_array_offset, the_array_length);
+    recompute_values();
+}
+
+recompute_values = function() {
+    the_array_display = string_join_ext(",", the_array);
+    the_array_max = array_max(the_array, the_array_offset, the_array_length);
+    the_array_min = array_min(the_array, the_array_offset, the_array_length);
+    the_array_median = array_median(the_array, the_array_offset, the_array_length);
+    the_array_mean = array_mean(the_array, the_array_offset, the_array_length);
+    the_array_sum = array_sum(the_array, the_array_offset, the_array_length);
+}
+
+
+reset_defaults();
+
 
 // Creating UI controls
 
 instance_create_layer(32, 80, layer, ui_Button, {
     text: "Change Array", on_click: popup_input_array, image_xscale: 6
+});
+
+instance_create_layer(256+32, 80, layer, ui_Button, {
+    text: "Set offset", on_click: set_offset_array, image_xscale: 6
+});
+
+instance_create_layer(256*2+32, 80, layer, ui_Button, {
+    text: "Set length", on_click: set_length_array, image_xscale: 6
+});
+
+
+
+instance_create_layer(32, 300, layer, ui_Button, {
+    text: "Get Random", on_click: get_random_array, image_xscale: 6
+});
+
+instance_create_layer(256+32, 300, layer, ui_Button, {
+    text: "Pop Random", on_click: pop_random_array, image_xscale: 6
+});
+
+instance_create_layer(256*2+32, 300, layer, ui_Button, {
+    text: "Reset to Defaults", on_click: reset_defaults, image_xscale: 6
 });

--- a/Community Toolbox/objects/ctrl_ArrayUtilities/Create_0.gml
+++ b/Community Toolbox/objects/ctrl_ArrayUtilities/Create_0.gml
@@ -1,5 +1,7 @@
 title = "Array Utilities";
-description = "Calculate the maximum, minimum, median, mean, and sum, and get/pop random values, of an array.";
+description =
+    "Calculates the maximum, minimum, median, mean, and sum of an array.\n" +
+    "Also, allows getting/popping random values from the array.";
 
 the_original_array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
@@ -34,15 +36,15 @@ popup_input_array = function() {
     }
 }
 
-set_offset_array = function() {
+set_array_offset = function() {
     if (input_offset == -1) {
-        input_offset = get_string_async("Enter the offset to consider for operations:", the_array_offset);
+        input_offset = get_string_async("Enter the offset to consider for operations:", string(the_array_offset));
     }
 }
 
-set_length_array = function() {
+set_array_length = function() {
     if (input_length == -1) {
-        input_length = get_string_async("Enter the length to consider for operations:", the_array_length);
+        input_length = get_string_async("Enter the length to consider for operations:", string(the_array_length));
     }
 }
 
@@ -70,28 +72,28 @@ reset_defaults();
 
 // Creating UI controls
 
-instance_create_layer(32, 80, layer, ui_Button, {
+instance_create_layer(32, 96, layer, ui_Button, {
     text: "Change Array", on_click: popup_input_array, image_xscale: 6
 });
 
-instance_create_layer(256+32, 80, layer, ui_Button, {
-    text: "Set offset", on_click: set_offset_array, image_xscale: 6
+instance_create_layer(672, 96, layer, ui_Button, {
+    text: "Set offset", on_click: set_array_offset, image_xscale: 6
 });
 
-instance_create_layer(256*2+32, 80, layer, ui_Button, {
-    text: "Set length", on_click: set_length_array, image_xscale: 6
+instance_create_layer(672, 192, layer, ui_Button, {
+    text: "Set length", on_click: set_array_length, image_xscale: 6
 });
 
 
 
-instance_create_layer(32, 300, layer, ui_Button, {
+instance_create_layer(32, 316, layer, ui_Button, {
     text: "Get Random", on_click: get_random_array, image_xscale: 6
 });
 
-instance_create_layer(256+32, 300, layer, ui_Button, {
+instance_create_layer(256+32, 316, layer, ui_Button, {
     text: "Pop Random", on_click: pop_random_array, image_xscale: 6
 });
 
-instance_create_layer(256*2+32, 300, layer, ui_Button, {
+instance_create_layer(256*2+32, 316, layer, ui_Button, {
     text: "Reset to Defaults", on_click: reset_defaults, image_xscale: 6
 });

--- a/Community Toolbox/objects/ctrl_ArrayUtilities/Draw_64.gml
+++ b/Community Toolbox/objects/ctrl_ArrayUtilities/Draw_64.gml
@@ -3,7 +3,7 @@ draw_set_halign(fa_left);
 draw_set_valign(fa_top);
 
 draw_text(16, 16, title);
-draw_text_ext(16, 48, description, -1, room_width - 352);
+draw_text_ext(16, 48, description, -1, room_width - 320);
 
 draw_text(
     16,
@@ -15,3 +15,23 @@ draw_text(
     $"array_mean(array): {the_array_mean}\n" +
     $"array_sum(array): {the_array_sum}\n"
     );
+
+draw_text(
+    256 + 32,
+    128,
+    $"offset: {the_array_offset}");
+    
+
+draw_text(
+    256 * 2 + 32,
+    128,
+    $"length: {the_array_length}");
+    
+
+draw_text(
+    16,
+    384,
+    $"last gotten value: {last_value_get}\n" + 
+    $"last popped value: {last_value_pop}\n"
+    );
+    

--- a/Community Toolbox/objects/ctrl_ArrayUtilities/Draw_64.gml
+++ b/Community Toolbox/objects/ctrl_ArrayUtilities/Draw_64.gml
@@ -7,7 +7,7 @@ draw_text_ext(16, 48, description, -1, room_width - 320);
 
 draw_text(
     16,
-    128,
+    144,
     $"array: {the_array_display}\n\n" +
     $"array_max(array): {the_array_max}\n" +
     $"array_min(array): {the_array_min}\n" +
@@ -17,21 +17,20 @@ draw_text(
     );
 
 draw_text(
-    256 + 32,
-    128,
-    $"offset: {the_array_offset}");
-    
+    672,
+    144,
+    $"offset: {the_array_offset}"
+    );
 
 draw_text(
-    256 * 2 + 32,
-    128,
-    $"length: {the_array_length}");
-    
+    672,
+    240,
+    $"length: {the_array_length}"
+    );
 
 draw_text(
     16,
-    384,
-    $"last gotten value: {last_value_get}\n" + 
-    $"last popped value: {last_value_pop}\n"
+    400,
+    $"last got random value: {last_value_get}\n" + 
+    $"last popped random value: {last_value_pop}\n"
     );
-    

--- a/Community Toolbox/objects/ctrl_ArrayUtilities/Other_63.gml
+++ b/Community Toolbox/objects/ctrl_ArrayUtilities/Other_63.gml
@@ -16,3 +16,25 @@ if (async_load[? "id"] == input_array) {
     }
     input_array = -1;
 }
+
+if (async_load[? "id"] == input_offset) {
+    if (async_load[? "status"]) {
+        try {
+            the_array_offset = real(async_load[? "result"]);
+        }
+        catch (ex) {}
+        recompute_values();
+    }
+    input_offset = -1;
+}
+
+if (async_load[? "id"] == input_length) {
+    if (async_load[? "status"]) {
+        try {
+            the_array_length = real(async_load[? "result"]);
+        }
+        catch (ex) {}
+        recompute_values();
+    }
+    input_length = -1;
+}

--- a/Community Toolbox/scripts/suite_ArrayUtilsSuite/suite_ArrayUtilsSuite.gml
+++ b/Community Toolbox/scripts/suite_ArrayUtilsSuite/suite_ArrayUtilsSuite.gml
@@ -5,6 +5,8 @@ function ArrayUtilsSuite() : VerrificSuiteGroup("Array utilities tests") constru
         ArrayMeanTests,
         ArrayMedianTests,
         ArraySumTests,
+		ArrayGetRandomTests,
+		ArrayPopRandomTests,
     ], function(test) {
         add_methods_from(test);
     });

--- a/Community Toolbox/scripts/suite_ArrayUtilsSuite/suite_ArrayUtilsSuite.gml
+++ b/Community Toolbox/scripts/suite_ArrayUtilsSuite/suite_ArrayUtilsSuite.gml
@@ -5,8 +5,8 @@ function ArrayUtilsSuite() : VerrificSuiteGroup("Array utilities tests") constru
         ArrayMeanTests,
         ArrayMedianTests,
         ArraySumTests,
-		ArrayGetRandomTests,
-		ArrayPopRandomTests,
+        ArrayGetRandomTests,
+        ArrayPopRandomTests,
     ], function(test) {
         add_methods_from(test);
     });

--- a/Community Toolbox/scripts/tests_ArrayGetRandomTests/tests_ArrayGetRandomTests.gml
+++ b/Community Toolbox/scripts/tests_ArrayGetRandomTests/tests_ArrayGetRandomTests.gml
@@ -1,0 +1,101 @@
+function ArrayGetRandomTests(_run, _method) : VerrificMethodTest(_run, _method) constructor {
+    static test_subject = "array_get_random";
+
+    static should_handle_empty_array = function() {
+        given_array([]);
+        when_array_get_random_runs();
+        then_result().should_be(0);
+    }
+    
+    static should_return_value_from_original_array = function() {
+        given_array([100, 300, 500, 700, 900]);
+        when_array_get_random_runs();
+        then_result().should_be_one_of([100, 300, 500, 700, 900]);
+    }
+    
+    static should_return_value_from_original_1_length_array = function() {
+        given_array(["Hi"]);
+        when_array_get_random_runs();
+        then_string_result().should_be("Hi");
+    }
+    
+    static should_respect_offset = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_offset(3);
+        when_array_get_random_runs();
+        then_result().should_be_one_of([4,5,6,7,8,9,0]);
+    }
+    
+    static should_respect_length = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_length(4);
+        when_array_get_random_runs();
+        then_result().should_be_one_of([1,2,3,4]);
+    }
+    
+    static should_respect_negative_offset = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_offset(-3);
+        when_array_get_random_runs();
+        then_result().should_be_one_of([8,9,0]);
+    }
+    
+    static should_respect_negative_length = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_offset(5);
+        given_length(-2);
+        when_array_get_random_runs();
+        then_result().should_be_one_of([5,6]);
+    }
+    
+    static should_return_zero_for_zero_length = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_length(0);
+        when_array_get_random_runs();
+        then_result().should_be(0);
+    }
+    
+    static should_respect_negative_offset_and_positive_length = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_offset(-5);
+        given_length(4);
+        when_array_get_random_runs();
+        then_result().should_be_one_of([6,7,8,9]);
+    }
+    
+ 
+    // -----
+    // Setup
+    // -----
+    
+    array = [];
+    offset = undefined;
+    length = undefined;
+    result = undefined;
+        
+    static given_array = function(_array) {
+        array = _array; 
+        offset = undefined;
+        length = undefined;
+    }
+    
+    static given_offset = function(_offset) {
+        offset = _offset;
+    }
+    
+    static given_length = function(_length) {
+        length = _length;        
+    }
+    
+    static when_array_get_random_runs = function() {
+        result = array_get_random(array, offset, length);
+    }
+        
+    static then_result = function() {
+        return new VerrificNumericAssertion(test_asserter, result);
+    }
+    
+    static then_string_result = function() {
+        return new VerrificStringAssertion(test_asserter, result);
+    }
+}

--- a/Community Toolbox/scripts/tests_ArrayGetRandomTests/tests_ArrayGetRandomTests.yy
+++ b/Community Toolbox/scripts/tests_ArrayGetRandomTests/tests_ArrayGetRandomTests.yy
@@ -1,0 +1,11 @@
+{
+  "resourceType": "GMScript",
+  "resourceVersion": "1.0",
+  "name": "tests_ArrayGetRandomTests",
+  "isCompatibility": false,
+  "isDnD": false,
+  "parent": {
+    "name": "Array",
+    "path": "folders/Tests/Array.yy",
+  },
+}

--- a/Community Toolbox/scripts/tests_ArrayMeanTests/tests_ArrayMeanTests.gml
+++ b/Community Toolbox/scripts/tests_ArrayMeanTests/tests_ArrayMeanTests.gml
@@ -30,18 +30,18 @@ function ArrayMeanTests(_run, _method) : VerrificMethodTest(_run, _method) const
         then_result().should_be(49_999.5);
     }
     
-    static should_handle_positive_offset_and_length = function() {
-        given_array([1, 6, 2, 7, 3, 8, 4, 9, 5, 0]);
-        given_offset_and_length(3, 4); // should take [7, 3, 8, 4]
-        when_array_mean_runs();
-        then_result().should_be(5.5);
-    }
-    
     static should_handle_offset_only = function() {
         given_array([4, 6, 5, 1, 3, 2]);
         given_offset(3); // should take [1, 3, 2]
         when_array_mean_runs();
         then_result().should_be(2);
+    }
+    
+    static should_handle_positive_offset_and_length = function() {
+        given_array([1, 6, 2, 7, 3, 8, 4, 9, 5, 0]);
+        given_offset_and_length(3, 4); // should take [7, 3, 8, 4]
+        when_array_mean_runs();
+        then_result().should_be(5.5);
     }
     
     static should_handle_negative_offset = function() {

--- a/Community Toolbox/scripts/tests_ArrayMedianTests/tests_ArrayMedianTests.gml
+++ b/Community Toolbox/scripts/tests_ArrayMedianTests/tests_ArrayMedianTests.gml
@@ -37,18 +37,18 @@ function ArrayMedianTests(_run, _method) : VerrificMethodTest(_run, _method) con
         then_result().should_be(50_000);
     }
     
-    static should_handle_positive_offset_and_length = function() {
-        given_array([1, 6, 2, 7, 3, 8, 4, 9, 5, 0]);
-        given_offset_and_length(3, 4); // should take [7, 3, 8, 4]
-        when_array_median_runs();
-        then_result().should_be(7);
-    }
-    
     static should_handle_offset_only = function() {
         given_array([4, 6, 5, 1, 3, 2]);
         given_offset(3); // should take [1, 3, 2]
         when_array_median_runs();
         then_result().should_be(2);
+    }
+    
+    static should_handle_positive_offset_and_length = function() {
+        given_array([1, 6, 2, 7, 3, 8, 4, 9, 5, 0]);
+        given_offset_and_length(3, 4); // should take [7, 3, 8, 4]
+        when_array_median_runs();
+        then_result().should_be(7);
     }
     
     static should_handle_negative_offset = function() {

--- a/Community Toolbox/scripts/tests_ArrayPopRandomTests/tests_ArrayPopRandomTests.gml
+++ b/Community Toolbox/scripts/tests_ArrayPopRandomTests/tests_ArrayPopRandomTests.gml
@@ -1,0 +1,111 @@
+function ArrayPopRandomTests(_run, _method) : VerrificMethodTest(_run, _method) constructor {
+    static test_subject = "array_pop_random";
+    
+    static should_handle_empty_array = function() {
+        given_array([]);
+        when_array_pop_random_runs();
+        then_result().should_be(0);
+    }
+    
+    static should_return_value_from_original_array = function() {
+        given_array([100, 300, 500, 700, 900]);
+        when_array_pop_random_runs();
+        then_result().should_be_one_of([100, 300, 500, 700, 900]);
+    }
+    
+    static should_return_value_from_original_1_length_array = function() {
+        given_array(["Hi"]);
+        when_array_pop_random_runs();
+        then_string_result().should_be("Hi");
+    }
+    
+    static should_return_empty_array_when_running_over_1_length_array = function() {
+        given_array(["Hi"]);
+        after_array_pop_random_runs_and_result_is_array_length();
+        then_result().should_be(0);
+    }
+    
+    static should_respect_offset = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_offset(3);
+        when_array_pop_random_runs();
+        then_result().should_be_one_of([4,5,6,7,8,9,0]);
+    }
+    
+    static should_respect_length = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_length(4);
+        when_array_pop_random_runs();
+        then_result().should_be_one_of([1,2,3,4]);
+    }
+    
+    static should_respect_negative_offset = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_offset(-3);
+        when_array_pop_random_runs();
+        then_result().should_be_one_of([8,9,0]);
+    }
+    
+    static should_respect_negative_length = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_offset(5);
+        given_length(-2);
+        when_array_pop_random_runs();
+        then_result().should_be_one_of([5,6]);
+    }
+    
+    static should_respect_negative_offset_and_length = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_offset(-3);
+        given_length(-4);
+        when_array_pop_random_runs();
+        then_result().should_be_one_of([5,6,7,8]);
+    }
+    
+    static should_handle_zero_length = function() {
+        given_array([1,2,3,4,5,6,7,8,9,0]);
+        given_length(0);
+        when_array_pop_random_runs();
+        then_result().should_be(0);
+    }
+    
+    // -----
+    // Setup
+    // -----
+    
+    array = [];
+    offset = undefined;
+    length = undefined;
+    result = undefined;
+    
+    static given_array = function(_array) {
+        array = _array; 
+        offset = undefined;
+        length = undefined;
+    }
+    
+    static given_offset = function(_offset) {
+        offset = _offset;
+    }
+    
+    static given_length = function(_length) {
+        length = _length;        
+    }
+    
+    static when_array_pop_random_runs = function() {
+        result = array_pop_random(array, offset, length);
+    }
+    
+    static after_array_pop_random_runs_and_result_is_array_length = function() {
+        var _elem = array_pop_random(array, offset, length);
+        result = array_length(array);
+    }
+        
+    static then_result = function() {
+        return new VerrificNumericAssertion(test_asserter, result);
+    }
+    
+    static then_string_result = function() {
+        return new VerrificStringAssertion(test_asserter, result);
+    }
+}

--- a/Community Toolbox/scripts/tests_ArrayPopRandomTests/tests_ArrayPopRandomTests.gml
+++ b/Community Toolbox/scripts/tests_ArrayPopRandomTests/tests_ArrayPopRandomTests.gml
@@ -1,111 +1,157 @@
+// general note: since array_pop_random is non-deterministic
+// the tests might technically pass even if there is an error by getting "lucky" with the RNG state;
+// what should be guaranteed, is that as long as the function is implemented correctly, the tests pass every time
+
 function ArrayPopRandomTests(_run, _method) : VerrificMethodTest(_run, _method) constructor {
     static test_subject = "array_pop_random";
     
-    static should_handle_empty_array = function() {
+    static should_return_undefined_for_empty_array = function() {
         given_array([]);
         when_array_pop_random_runs();
-        then_result().should_be(0);
+        then_result().should_be_undefined();
+        then_source_array_length().should_be(0);
     }
     
-    static should_return_value_from_original_array = function() {
+    static should_pop_value_from_single_item_array = function() {
+        given_array([42]);
+        when_array_pop_random_runs();
+        then_result().should_be(42);
+        then_source_array_length().should_be(0);
+    }
+    
+    static should_pop_value_from_multi_item_array = function() {
         given_array([100, 300, 500, 700, 900]);
         when_array_pop_random_runs();
         then_result().should_be_one_of([100, 300, 500, 700, 900]);
+        then_source_array_length().should_be(4);
     }
     
-    static should_return_value_from_original_1_length_array = function() {
-        given_array(["Hi"]);
+    static should_pop_values_until_no_items_left = function() {
+        given_array([100, 300, 500]);
+        
         when_array_pop_random_runs();
-        then_string_result().should_be("Hi");
-    }
-    
-    static should_return_empty_array_when_running_over_1_length_array = function() {
-        given_array(["Hi"]);
-        after_array_pop_random_runs_and_result_is_array_length();
-        then_result().should_be(0);
-    }
-    
-    static should_respect_offset = function() {
-        given_array([1,2,3,4,5,6,7,8,9,0]);
-        given_offset(3);
+        then_result().should_be_one_of([100, 300, 500]);
+        then_source_array_length().should_be(2);
+        
         when_array_pop_random_runs();
-        then_result().should_be_one_of([4,5,6,7,8,9,0]);
+        then_result().should_be_one_of([100, 300, 500]);
+        then_source_array_length().should_be(1);
+
+        when_array_pop_random_runs();
+        then_result().should_be_one_of([100, 300, 500]);
+        then_source_array_length().should_be(0);
+
+        when_array_pop_random_runs();
+        then_result().should_be_undefined();
+        then_source_array_length().should_be(0);
+        
+        then_popped_items_must_include(100, 300, 500);
     }
     
-    static should_respect_length = function() {
-        given_array([1,2,3,4,5,6,7,8,9,0]);
-        given_length(4);
+    static should_handle_offset_only = function() {
+        given_array([100, 300, 500, 700, 900]);
+        given_offset(2); // should take [500, 700, 900]
         when_array_pop_random_runs();
-        then_result().should_be_one_of([1,2,3,4]);
+        then_result().should_be_one_of([500, 700, 900]);
+        then_source_array_length().should_be(4);
     }
     
-    static should_respect_negative_offset = function() {
-        given_array([1,2,3,4,5,6,7,8,9,0]);
-        given_offset(-3);
+    static should_handle_positive_offset_and_length = function() {
+        given_array([100, 300, 500, 700, 900]);
+        given_offset_and_length(2, 1); // should take [500]
         when_array_pop_random_runs();
-        then_result().should_be_one_of([8,9,0]);
+        then_result().should_be(500);
+        then_source_array_length().should_be(4);
     }
     
-    static should_respect_negative_length = function() {
-        given_array([1,2,3,4,5,6,7,8,9,0]);
-        given_offset(5);
-        given_length(-2);
+    static should_handle_negative_offset = function() {
+        given_array([100, 300, 500, 700, 900]);
+        given_offset_and_length(-2, 1); // should_take [700]
         when_array_pop_random_runs();
-        then_result().should_be_one_of([5,6]);
+        then_result().should_be(700);
+        then_source_array_length().should_be(4);
     }
     
-    static should_respect_negative_offset_and_length = function() {
-        given_array([1,2,3,4,5,6,7,8,9,0]);
-        given_offset(-3);
-        given_length(-4);
+    static should_handle_negative_length = function() {
+        given_array([100, 300, 500, 700, 900]);
+        given_offset_and_length(3, -3); // should take [700, 500, 300]
         when_array_pop_random_runs();
-        then_result().should_be_one_of([5,6,7,8]);
+        then_result().should_be_one_of([300, 500, 700]);
+        then_source_array_length().should_be(4);
     }
     
-    static should_handle_zero_length = function() {
-        given_array([1,2,3,4,5,6,7,8,9,0]);
-        given_length(0);
+    static should_handle_zero_length_subsection = function() {
+        given_array([100, 300, 500, 700, 900]);
+        given_offset_and_length(2, 0);
         when_array_pop_random_runs();
-        then_result().should_be(0);
+        then_result().should_be_undefined();
+        then_source_array_length().should_be(5);
+    }
+    
+    static should_pop_subsection_values_until_no_items_left = function() {
+        // note: using an array-ending subsection for repeated popping tests
+        // because otherwise the items after the subsection would enter the subsection range
+        given_array([100, 300, 500, 700, 900]);
+        given_offset_and_length(2, 3);
+        
+        when_array_pop_random_runs();
+        then_result().should_be_one_of([500, 700, 900]);
+        then_source_array_length().should_be(4);
+        
+        when_array_pop_random_runs();
+        then_result().should_be_one_of([500, 700, 900]);
+        then_source_array_length().should_be(3);
+
+        when_array_pop_random_runs();
+        then_result().should_be_one_of([500, 700, 900]);
+        then_source_array_length().should_be(2);
+
+        when_array_pop_random_runs();
+        then_result().should_be_undefined();
+        then_source_array_length().should_be(2);
+        
+        then_popped_items_must_include(500, 700, 900);
     }
     
     // -----
     // Setup
     // -----
     
-    array = [];
+    source_array = [];
     offset = undefined;
     length = undefined;
     result = undefined;
+    popped_items = [];
     
     static given_array = function(_array) {
-        array = _array; 
-        offset = undefined;
-        length = undefined;
+        source_array = _array;
     }
     
     static given_offset = function(_offset) {
         offset = _offset;
     }
     
-    static given_length = function(_length) {
-        length = _length;        
+    static given_offset_and_length = function(_offset, _length) {
+        offset = _offset;
+        length = _length;
     }
     
     static when_array_pop_random_runs = function() {
-        result = array_pop_random(array, offset, length);
+        result = array_pop_random(source_array, offset, length);
+        array_push(popped_items, result);
     }
     
-    static after_array_pop_random_runs_and_result_is_array_length = function() {
-        var _elem = array_pop_random(array, offset, length);
-        result = array_length(array);
-    }
-        
     static then_result = function() {
         return new VerrificNumericAssertion(test_asserter, result);
     }
     
-    static then_string_result = function() {
-        return new VerrificStringAssertion(test_asserter, result);
+    static then_source_array_length = function() {
+        return new VerrificNumericAssertion(test_asserter, array_length(source_array));
+    }
+    
+    static then_popped_items_must_include = function() {
+        for (var i = 0; i < argument_count; i++) {
+            assert_that(array_contains(popped_items, argument[i]), $"Expected popped items to include {argument[i]}, but only {popped_items} were found.");
+        }
     }
 }

--- a/Community Toolbox/scripts/tests_ArrayPopRandomTests/tests_ArrayPopRandomTests.gml
+++ b/Community Toolbox/scripts/tests_ArrayPopRandomTests/tests_ArrayPopRandomTests.gml
@@ -17,6 +17,7 @@ function ArrayPopRandomTests(_run, _method) : VerrificMethodTest(_run, _method) 
         when_array_pop_random_runs();
         then_result().should_be(42);
         then_source_array_length().should_be(0);
+        then_source_array_should_not_have_result();
     }
     
     static should_pop_value_from_multi_item_array = function() {
@@ -24,6 +25,7 @@ function ArrayPopRandomTests(_run, _method) : VerrificMethodTest(_run, _method) 
         when_array_pop_random_runs();
         then_result().should_be_one_of([100, 300, 500, 700, 900]);
         then_source_array_length().should_be(4);
+        then_source_array_should_not_have_result();
     }
     
     static should_pop_values_until_no_items_left = function() {
@@ -32,14 +34,17 @@ function ArrayPopRandomTests(_run, _method) : VerrificMethodTest(_run, _method) 
         when_array_pop_random_runs();
         then_result().should_be_one_of([100, 300, 500]);
         then_source_array_length().should_be(2);
+        then_source_array_should_not_have_result();
         
         when_array_pop_random_runs();
         then_result().should_be_one_of([100, 300, 500]);
         then_source_array_length().should_be(1);
+        then_source_array_should_not_have_result();
 
         when_array_pop_random_runs();
         then_result().should_be_one_of([100, 300, 500]);
         then_source_array_length().should_be(0);
+        then_source_array_should_not_have_result();
 
         when_array_pop_random_runs();
         then_result().should_be_undefined();
@@ -54,6 +59,7 @@ function ArrayPopRandomTests(_run, _method) : VerrificMethodTest(_run, _method) 
         when_array_pop_random_runs();
         then_result().should_be_one_of([500, 700, 900]);
         then_source_array_length().should_be(4);
+        then_source_array_should_not_have_result();
     }
     
     static should_handle_positive_offset_and_length = function() {
@@ -70,6 +76,7 @@ function ArrayPopRandomTests(_run, _method) : VerrificMethodTest(_run, _method) 
         when_array_pop_random_runs();
         then_result().should_be(700);
         then_source_array_length().should_be(4);
+        then_source_array_should_not_have_result();
     }
     
     static should_handle_negative_length = function() {
@@ -78,6 +85,7 @@ function ArrayPopRandomTests(_run, _method) : VerrificMethodTest(_run, _method) 
         when_array_pop_random_runs();
         then_result().should_be_one_of([300, 500, 700]);
         then_source_array_length().should_be(4);
+        then_source_array_should_not_have_result();
     }
     
     static should_handle_zero_length_subsection = function() {
@@ -97,15 +105,18 @@ function ArrayPopRandomTests(_run, _method) : VerrificMethodTest(_run, _method) 
         when_array_pop_random_runs();
         then_result().should_be_one_of([500, 700, 900]);
         then_source_array_length().should_be(4);
+        then_source_array_should_not_have_result();
         
         when_array_pop_random_runs();
         then_result().should_be_one_of([500, 700, 900]);
         then_source_array_length().should_be(3);
-
+        then_source_array_should_not_have_result();
+        
         when_array_pop_random_runs();
         then_result().should_be_one_of([500, 700, 900]);
         then_source_array_length().should_be(2);
-
+        then_source_array_should_not_have_result();
+        
         when_array_pop_random_runs();
         then_result().should_be_undefined();
         then_source_array_length().should_be(2);
@@ -147,6 +158,10 @@ function ArrayPopRandomTests(_run, _method) : VerrificMethodTest(_run, _method) 
     
     static then_source_array_length = function() {
         return new VerrificNumericAssertion(test_asserter, array_length(source_array));
+    }
+    
+    static then_source_array_should_not_have_result = function() {
+        assert_that(!array_contains(source_array, result), $"Expected source array not to contain the result {result}, but it's {source_array} instead.");
     }
     
     static then_popped_items_must_include = function() {

--- a/Community Toolbox/scripts/tests_ArrayPopRandomTests/tests_ArrayPopRandomTests.yy
+++ b/Community Toolbox/scripts/tests_ArrayPopRandomTests/tests_ArrayPopRandomTests.yy
@@ -1,0 +1,11 @@
+{
+  "resourceType": "GMScript",
+  "resourceVersion": "1.0",
+  "name": "tests_ArrayPopRandomTests",
+  "isCompatibility": false,
+  "isDnD": false,
+  "parent": {
+    "name": "Array",
+    "path": "folders/Tests/Array.yy",
+  },
+}

--- a/Community Toolbox/scripts/utils_Array/utils_Array.gml
+++ b/Community Toolbox/scripts/utils_Array/utils_Array.gml
@@ -172,3 +172,62 @@ function array_sum(_array, _offset = 0, _length = undefined) {
         return array_reduce(_array, function(_previous, _current) { return _previous + _current; }, 0, _offset, _length);
     }
 }
+
+/// @func       array_get_random(array,[offset],[length])
+/// @desc       Returns a random element from the array (or a range within it). If the array/subsection is empty it will return zero.
+/// @arg        {Array<Real>}    array       the desired array
+/// @arg        {Real}           [offset]    optional 0-based offset to use. By default 0. Can be negative (will wrap around)
+/// @arg        {Real}           [length]    optional length of items to select from, starting from offset (for a negative length, it will count backwards from the offset position). By default array_length(array).
+/// @returns    {Any}            a random item from the array
+function array_get_random(_array, _offset=0, _length=undefined) {
+    // resolving the offset and length
+    var _arrlength = array_length(_array);
+    _length ??= _arrlength;
+    
+    if (_offset < 0)
+        _offset = max(_arrlength + _offset, 0);
+    
+    if (_length < 0) {
+        _length = min(_offset + 1, -_length);
+        _offset -= _length - 1;
+    }
+    
+    _length = min(_arrlength - _offset, _length);
+    if (_length <= 0)
+        return 0;
+    
+	// getting the random value	
+    var _index = irandom_range(_offset, _offset + _length - 1);
+    return _array[_index];
+}
+
+
+/// @func       array_pop_random(array,[offset],[length])
+/// @desc       Pops a random element from the array (or a range within it). If the array is empty or the length is nonpositive it will return zero.
+/// @arg        {Array<Real>}    array       the desired array
+/// @arg        {Real}           [offset]    optional 0-based offset to use. By default 0. Can be negative (will wrap around)
+/// @arg        {Real}           [length]    optional length of items to select from, starting from offset (for a negative length, it will count backwards from the offset position). By default array_length(array).
+/// @returns    {Any}            a random item from the array
+function array_pop_random(_array, _offset=0, _length=undefined) {
+    // resolving the offset and length
+    var _arrlength = array_length(_array);
+    _length ??= _arrlength;
+    
+    if (_offset < 0)
+        _offset = max(_arrlength + _offset, 0);
+    
+    if (_length < 0) {
+        _length = min(_offset + 1, -_length);
+        _offset -= _length - 1;
+    }
+    
+    _length = min(_arrlength - _offset, _length);
+    if (_length <= 0)
+        return 0;
+    
+    // popping the value
+    var _index = irandom_range(_offset, _offset + _length - 1);
+    var _element = _array[_index];
+    array_delete(_array, _index, 1);
+    return _element;        
+}

--- a/Community Toolbox/scripts/utils_Array/utils_Array.gml
+++ b/Community Toolbox/scripts/utils_Array/utils_Array.gml
@@ -1,3 +1,5 @@
+#region Array-wide maths
+
 /// @func array_max(array,[offset],[length])
 /// @desc Returns the highest number from the array or its subsection. If the array/subsection is empty, 0 is returned.
 /// @arg {Array<Real>} array    The array to get the maximum value of.
@@ -173,13 +175,17 @@ function array_sum(_array, _offset = 0, _length = undefined) {
     }
 }
 
-/// @func       array_get_random(array,[offset],[length])
-/// @desc       Returns a random element from the array (or a range within it). If the array/subsection is empty it will return zero.
-/// @arg        {Array<Real>}    array       the desired array
-/// @arg        {Real}           [offset]    optional 0-based offset to use. By default 0. Can be negative (will wrap around)
-/// @arg        {Real}           [length]    optional length of items to select from, starting from offset (for a negative length, it will count backwards from the offset position). By default array_length(array).
-/// @returns    {Any}            a random item from the array
-function array_get_random(_array, _offset=0, _length=undefined) {
+#endregion
+
+#region Random elements
+
+/// @func array_get_random(array,[offset],[length])
+/// @desc Returns a random element from the array or its subsection. If the array/subsection is empty, undefined is returned.
+/// @arg {Array} array          The array to get the random element from.
+/// @arg {Real} [offset]        The starting index of the subsection (for a negative offset, it will count from array end).
+/// @arg {Real} [length]        The length of the subsection (for a negative length, it will count backwards from the offset position).
+/// @returns {Any}
+function array_get_random(_array, _offset = 0, _length = undefined) {
     // resolving the offset and length
     var _arrlength = array_length(_array);
     _length ??= _arrlength;
@@ -194,21 +200,21 @@ function array_get_random(_array, _offset=0, _length=undefined) {
     
     _length = min(_arrlength - _offset, _length);
     if (_length <= 0)
-        return 0;
+        return undefined;
     
-	// getting the random value	
+    // getting the random value	
     var _index = irandom_range(_offset, _offset + _length - 1);
     return _array[_index];
 }
 
 
-/// @func       array_pop_random(array,[offset],[length])
-/// @desc       Pops a random element from the array (or a range within it). If the array is empty or the length is nonpositive it will return zero.
-/// @arg        {Array<Real>}    array       the desired array
-/// @arg        {Real}           [offset]    optional 0-based offset to use. By default 0. Can be negative (will wrap around)
-/// @arg        {Real}           [length]    optional length of items to select from, starting from offset (for a negative length, it will count backwards from the offset position). By default array_length(array).
-/// @returns    {Any}            a random item from the array
-function array_pop_random(_array, _offset=0, _length=undefined) {
+/// @func array_pop_random(array,[offset],[length])
+/// @desc Pops a random element from the array or its subsection. If the array/subsection is empty, undefined is returned.
+/// @arg {Array} array          The array to pop the random element from.
+/// @arg {Real} [offset]        The starting index of the subsection (for a negative offset, it will count from array end).
+/// @arg {Real} [length]        The length of the subsection (for a negative length, it will count backwards from the offset position).
+/// @returns {Any}
+function array_pop_random(_array, _offset = 0, _length = undefined) {
     // resolving the offset and length
     var _arrlength = array_length(_array);
     _length ??= _arrlength;
@@ -223,11 +229,13 @@ function array_pop_random(_array, _offset=0, _length=undefined) {
     
     _length = min(_arrlength - _offset, _length);
     if (_length <= 0)
-        return 0;
+        return undefined;
     
     // popping the value
     var _index = irandom_range(_offset, _offset + _length - 1);
     var _element = _array[_index];
     array_delete(_array, _index, 1);
-    return _element;        
+    return _element;
 }
+
+#endregion


### PR DESCRIPTION
Building upon biyectivo's implementation from PR #39. Changes include:
- returning undefined instead of 0 for empty arrays/subsections
- tweaking JSDoc formatting and phrasing in array random functions
- adding missing YY files and YYP references for test scripts
- reworking tests in various ways